### PR TITLE
Let railtie auto-include ActiveRecord::Acts::Tree

### DIFF
--- a/lib/acts_as_tree.rb
+++ b/lib/acts_as_tree.rb
@@ -1,2 +1,23 @@
 require 'acts_as_tree/active_record/acts/tree'
 require 'acts_as_tree/version'
+
+module ActsAsTree
+  if defined? Rails::Railtie
+    require 'rails'
+    class Railtie < Rails::Railtie
+      initializer 'acts_as_tree.insert_into_active_record' do
+        ActiveSupport.on_load :active_record do
+          ActsAsTree::Railtie.insert
+        end
+      end
+    end
+  end
+
+  class Railtie
+    def self.insert
+      if defined?(ActiveRecord)
+        ActiveRecord::Base.send(:include, ActiveRecord::Acts::Tree)
+      end
+    end
+  end
+end


### PR DESCRIPTION
To make the public API consistent with other `acts_as` libraries, such as `acts_as_list`.
