### PR TITLE
Add support for self_and_ancestors

### DIFF
--- a/lib/acts_as_tree.rb
+++ b/lib/acts_as_tree.rb
@@ -141,6 +141,13 @@ module ActsAsTree
       [self] + self.children
     end
 
+    # Returns ancestors and current node itself.
+    #
+    #   subchild1.self_and_ancestors # => [subchild1, child1, root]
+    def self_and_ancestors
+      [self] + self.ancestors
+    end
+
     private
 
     def update_parents_counter_cache

--- a/test/acts_as_tree_test.rb
+++ b/test/acts_as_tree_test.rb
@@ -161,6 +161,11 @@ class TreeTest < Test::Unit::TestCase
     assert_equal [@root2], @root2.self_and_children
   end
 
+  def test_self_and_ancestors
+    assert_equal [@child1_child, @root_child1, @root1], @child1_child.self_and_ancestors
+    assert_equal [@root2], @root2.self_and_ancestors
+  end
+
   def test_nullify
     root4       = TreeMixinNullify.create!
     root4_child = TreeMixinNullify.create! parent_id: root4.id


### PR DESCRIPTION
This adds a method self_and_ancestors, similar to self_and_children and the like. See comments/specs.

I needed this for a breadcrumb helper.
