### PR TITLE
This fixes a deprecation warning being thrown in Rails 4

### DIFF
--- a/lib/acts_as_tree.rb
+++ b/lib/acts_as_tree.rb
@@ -75,11 +75,19 @@ module ActsAsTree
         counter_cache: configuration[:counter_cache],
         inverse_of:    :children
 
-      has_many :children, -> { order configuration[:order] },
-        class_name:  name,
-        foreign_key: configuration[:foreign_key],
-        dependent:   configuration[:dependent],
-        inverse_of:  :parent
+      if Rails.version.to_i == 4
+        has_many :children, -> { order configuration[:order] },
+          class_name:  name,
+          foreign_key: configuration[:foreign_key],
+          dependent:   configuration[:dependent],
+          inverse_of:  :parent
+      else
+        has_many :children, class_name:  name,
+          foreign_key: configuration[:foreign_key],
+          order:       configuration[:order],
+          dependent:   configuration[:dependent],
+          inverse_of:  :parent
+      end
 
       class_eval <<-EOV
         include ActsAsTree::InstanceMethods


### PR DESCRIPTION
In Rails 4 you should not do the following any more:

```
has_many :children, order: configuration[:order], # Etc.
```

Instead it the order should be passed in a scope:

```
has_many :children, -> { order configuration[:order] }, # Etc.
```

This pull request fixes that.

Note: I'm relying on `Rails.version` to make sure the gem keeps working in Rails 3. Not sure if the way I've implemented that is desirable.
