### PR TITLE
Test all supported Rails versions on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,21 @@ language: ruby
 rvm:
   - 1.9.2
   - 1.9.3
-  - ruby-head
+  - 2.0.0
+
+gemfile:
+  - gemfiles/rails-3.0.gemfile
+  - gemfiles/rails-3.1.gemfile
+  - gemfiles/rails-3.2.gemfile
+  - gemfiles/rails-4.0.gemfile
+
+matrix:
+  exclude:
+    # rails 4.0 requries ruby 1.9.3 or newer
+    - rvm: 1.9.2
+      gemfile: gemfiles/rails-4.0.gemfile
+    # rails < 3.2 is unsupported on ruby 2.0
+    - rvm: 2.0.0
+      gemfile: gemfiles/rails-3.0.gemfile
+    - rvm: 2.0.0
+      gemfile: gemfiles/rails-3.1.gemfile

--- a/gemfiles/rails-3.0.gemfile
+++ b/gemfiles/rails-3.0.gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gem "rails", "~> 3.0"
+gem "acts_as_tree", path: "../"
+
+gemspec path: "../"

--- a/gemfiles/rails-3.1.gemfile
+++ b/gemfiles/rails-3.1.gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gem "rails", "~> 3.1"
+gem "acts_as_tree", path: "../"
+
+gemspec path: "../"

--- a/gemfiles/rails-3.2.gemfile
+++ b/gemfiles/rails-3.2.gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gem "rails", "~> 3.2"
+gem "acts_as_tree", path: "../"
+
+gemspec path: "../"

--- a/gemfiles/rails-4.0.gemfile
+++ b/gemfiles/rails-4.0.gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gem "rails", "~> 4.0.0.beta1"
+gem "acts_as_tree", path: "../"
+
+gemspec path: "../"


### PR DESCRIPTION
This modifies the Travis CI configuration so we test a matrix of supported ruby and rails combinations.

It also switches out ruby-head for 2.0.0, because it makes no sense to test against development versions of ruby.
