### PR TITLE
Methods to know if a node is root or leaf

### DIFF
--- a/lib/acts_as_tree.rb
+++ b/lib/acts_as_tree.rb
@@ -160,6 +160,14 @@ module ActsAsTree
       parent.nil?
     end
 
+    # Returns true if node has no children, false otherwise
+    #
+    #   subchild1.leaf? # => true
+    #   child1.leaf?    # => false
+    def leaf?
+      children.count == 0
+    end
+
     private
 
     def update_parents_counter_cache

--- a/test/acts_as_tree_test.rb
+++ b/test/acts_as_tree_test.rb
@@ -189,6 +189,18 @@ class TreeTest < Test::Unit::TestCase
     assert_equal false, @child1_child_child.root?
     assert_equal false, @root_child2.root?
   end
+
+  def test_is_leaf
+    assert_equal true, @root2.leaf?
+    assert_equal true, @root3.leaf?
+    assert_equal true, @child1_child_child.leaf?
+    assert_equal true, @root_child2.leaf?
+
+    assert_equal false, @root1.leaf?
+    assert_equal false, @root_child1.leaf?
+    assert_equal false, @child1_child.leaf?
+  end
+
 end
 
 class TreeTestWithEagerLoading < Test::Unit::TestCase


### PR DESCRIPTION
This PR adds a couple of methods:
`node.root?` returns true if node is a root (no parent)
`node.leaf?` returns true if node is a leaf (no children)
