### PR TITLE
fix warning

### DIFF
--- a/lib/acts_as_tree.rb
+++ b/lib/acts_as_tree.rb
@@ -100,7 +100,6 @@ module ActsAsTree
         end
 
         def self.root
-          order_option = %Q{#{configuration.fetch :order, "nil"}}
           self.roots.first
         end
       EOV


### PR DESCRIPTION
warning: assigned but unused variable - order_option
