### PR TITLE
Bugfix: descendants method must not modify the data structure

### DIFF
--- a/lib/acts_as_tree.rb
+++ b/lib/acts_as_tree.rb
@@ -152,9 +152,10 @@ module ActsAsTree
     #
     #   root.descendants # => [child1, child2, subchild1, subchild2, subchild3, subchild4]
     def descendants
-      children.each_with_object(children) {|child, arr|
+      children.each_with_object([]) {|child, arr|
+        arr << child
         arr.concat child.descendants
-      }.uniq
+      }
     end
 
     # Returns list of descendants, starting from current node, including current node.

--- a/test/acts_as_tree_test.rb
+++ b/test/acts_as_tree_test.rb
@@ -166,13 +166,25 @@ class TreeTest < Test::Unit::TestCase
     assert_equal [@root2], @root2.self_and_ancestors
   end
 
-  def test_self_and_descendants
-    assert_equal [@root1, @root_child1, @root_child2, @child1_child, @child1_child_child], @root1.self_and_descendants
+  def test_self_and_ancestorsants
+    children_count_before = @root1.children.count
+    ### Use to_set for equality, currently there's no guarantee for the order
+    assert_equal [@root1, @root_child1, @root_child2, @child1_child, @child1_child_child].to_set, @root1.self_and_descendants.to_set
+    ### check if the method call didn't modify the data structure
+    assert_equal children_count_before, @root1.children.count
+    
+    children_count_before = @root2.children.count
     assert_equal [@root2], @root2.self_and_descendants
+    assert_equal children_count_before, @root2.children.count
   end
 
   def test_descendants
-    assert_equal [@root_child1, @root_child2, @child1_child, @child1_child_child], @root1.descendants
+    children_count_before = @root1.children.count
+    ### Use to_set for equality, currently there's no guarantee for the order
+    assert_equal [@root_child1, @root_child2, @child1_child, @child1_child_child].to_set, @root1.descendants.to_set
+    ### check if the method call didn't modify the data structure
+    assert_equal children_count_before, @root1.children.count
+    
     assert_equal [], @root2.descendants
   end
 


### PR DESCRIPTION
I fixed a bug with the _descendants_ method. This method modifies the _children_ array of the tree element, so that the data structure is modified, when calling it. I fixed this and updated the unit tests.
Would be very nice if this fix would make it into the official repository.
