### PR TITLE
Add leaves scope

### DIFF
--- a/test/acts_as_tree_test.rb
+++ b/test/acts_as_tree_test.rb
@@ -67,6 +67,7 @@ class TreeTest < MiniTest::Unit::TestCase
 
   def setup
     setup_db
+
     @root1              = TreeMixin.create!
     @root_child1        = TreeMixin.create! parent_id: @root1.id
     @child1_child       = TreeMixin.create! parent_id: @root_child1.id
@@ -137,6 +138,14 @@ class TreeTest < MiniTest::Unit::TestCase
 
   def test_roots
     assert_equal [@root1, @root2, @root3], TreeMixin.roots
+  end
+
+  def test_leaves
+    assert_equal [@child1_child_child, @root_child2, @root2, @root3], TreeMixin.leaves
+  end
+
+  def test_default_tree_order
+    assert_equal [@root1, @root_child1, @child1_child, @child1_child_child, @root_child2, @root2, @root3], TreeMixin.default_tree_order
   end
 
   def test_siblings
@@ -408,4 +417,7 @@ class TreeTestWithCounterCache < MiniTest::Unit::TestCase
     assert_equal 0, @child1.reload.children_count
   end
 
+  def test_leaves
+    assert_equal [@child1_child1, @child2], TreeMixinWithCounterCache.leaves
+  end
 end


### PR DESCRIPTION
Hi. I'd like to use acts_as_tree in a project and one thing I would like in particular is an AR scope for the leaves of the tree, but it was unfortunately missing. This patch adds it. ~~It also converts `#roots` from a method to a scope to allow chaining.~~

~~Running the tests also complained that MiniTest::Unit::TestCase was renamed to MiniTest::Test.~~ (I didn't  `bundle exec rake`...)

I'm not sure if scopes are available in all AR versions acts_as_tree wants to support. Sorry if it's wrong to use them - I can fix that.
