### PR TITLE
Use counter cache when checking #leaf?

### DIFF
--- a/lib/acts_as_tree.rb
+++ b/lib/acts_as_tree.rb
@@ -232,7 +232,7 @@ module ActsAsTree
     #   subchild1.leaf? # => true
     #   child1.leaf?    # => false
     def leaf?
-      children.count == 0
+      children.size.zero?
     end
 
     private


### PR DESCRIPTION
Using #count does not use the counter_cache, but rather triggers a `SELECT COUNT(*)` query to the database.

One, better use `#size` instead of `#count`, so that counter caches are used.

Second, `#empty?` and `#any?` methods will use `#size` as well and are far more expressive.
