### PR TITLE
Add sentence about default requirement of parent_id to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [travis]: (http://travis-ci.org/amerine/acts_as_tree)
 
 
-ActsAsTree extends ActiveRecord to add simple support for organizing items into parent–children relationships.
+ActsAsTree extends ActiveRecord to add simple support for organizing items into parent–children relationships. By default, ActsAsTree expects a foreign key column called `parent_id`.
 
 ## Example
 


### PR DESCRIPTION
Having not used acts_as_tree before, not having this in the README tripped me up.
