### PR TITLE
Rename Presentation module to TreeView

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ root.children # => [child1]
 root.children.first.children.first # => subchild1
 ```
 
-We also have a convenient `Presentation` module you can mixin if you want a little visual representation of the tree strucuture. Example:
+We also have a convenient `TreeView` module you can mixin if you want a little visual representation of the tree strucuture. Example:
 
 ```ruby
 class Category < ActiveRecord::Base
-  extend ActsAsTree::Presentation
+  extend ActsAsTree::TreeView
 
   acts_as_tree order: "name"
 end

--- a/lib/acts_as_tree.rb
+++ b/lib/acts_as_tree.rb
@@ -135,7 +135,7 @@ module ActsAsTree
 
   end
 
-  module Presentation
+  module TreeView
     # show records in a tree view
     # Example:
     # root

--- a/test/acts_as_tree_test.rb
+++ b/test/acts_as_tree_test.rb
@@ -249,7 +249,7 @@ class TreeTest < MiniTest::Unit::TestCase
 
   def test_tree_view
     assert_equal false, Mixin.respond_to?(:tree_view)
-    Mixin.extend ActsAsTree::Presentation
+    Mixin.extend ActsAsTree::TreeView
     assert_equal true,  TreeMixin.respond_to?(:tree_view)
 
     tree_view_outputs = <<-END.gsub(/^ {6}/, '')


### PR DESCRIPTION
This avoids name clashes with models named Presentation. Fixes #27.
