### PR TITLE
TreeWalker module

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ root
 => nil
 ```
 
-And there's a `TreeWalker` module (simply walking the tree and calling a given block on each node) as well. Example:
+And there's a `TreeWalker` module (traversing the tree using depth-first search (default) or breadth-first search) as well. Example given the Model `Page` as
 
 ```ruby
 class Page < ActiveRecord::Base
@@ -51,11 +51,11 @@ class Page < ActiveRecord::Base
 end
 ```
 
-And in your view:
+In your view you could traverse the tree using
 
 ```erb
-<% Page.walk_tree(:indent => '&mdash;') do |page, indent| %>
-  <%= link_to "#{indent}#{page.name}", page_path(@page) %><br />
+<% Page.walk_tree do |page, level| %>
+  <%= link_to "#{'-'*level}#{page.name}", page_path(page) %><br />
 <% end %>
 ```
 

--- a/lib/acts_as_tree.rb
+++ b/lib/acts_as_tree.rb
@@ -167,21 +167,45 @@ module ActsAsTree
   end
 
   module TreeWalker
-    # call block with each element in the tree
-    # Example of acts_as_tree model Page (ERB view):
-    # <% Page.walk_tree(:indent => '&mdash;') do |page, indent| %>
-    #   <%= link_to (indent.html_safe << page.name), page_path(@page) %><br />
+    # Traverse the tree and call a block with the current node and current
+    # depth-level.
+    #
+    # options:
+    #   algorithm:
+    #     :dfs for depth-first search (default)
+    #     :bfs for breadth-first search
+    #   where: AR where statement to filter certain nodes
+    #
+    # The given block sets two parameters:
+    #   first: The current node
+    #   second: The current depth-level within the tree
+    #
+    # Example of acts_as_tree for model Page (ERB view):
+    # <% Page.walk_tree do |page, level| %>
+    #   <%= link_to "#{' '*level}#{page.name}", page_path(page) %><br />
     # <% end %>
-    def walk_tree(_options = {}, indent = '', node = nil, &block)
-      options = {:indent => '-', :where_statement => {}}.update(_options)
-      if node.nil?
-        roots.each do |root_node|
-          walk_tree(options, indent, root_node, &block)
+    #
+    def walk_tree(_options = {}, level = 0, node = nil, &block)
+      options = {:algorithm => :dfs, :where => {}}.update(_options)
+      case options[:algorithm]
+      when :bfs
+        nodes = (node.nil? ? roots : node.children).where(options[:where])
+        nodes.each do |child|
+          block.call child, level
+        end
+        nodes.each do |child|
+          walk_tree options, level + 1, child, &block
         end
       else
-        block.call(node, indent)
-        node.children.where(options[:where_statement]).each do |child|
-          walk_tree(options, "#{indent}#{options[:indent]}", child, &block)
+        if node.nil?
+          roots.where(options[:where]).each do |root_node|
+            walk_tree options, level, root_node, &block
+          end
+        else
+          block.call node, level
+          node.children.where(options[:where]).each do |child|
+            walk_tree options, level + 1, child, &block
+          end
         end
       end
     end

--- a/test/acts_as_tree_test.rb
+++ b/test/acts_as_tree_test.rb
@@ -266,11 +266,11 @@ class TreeTest < MiniTest::Unit::TestCase
   end
 
   def test_tree_walker
-    assert_equal false, Mixin.respond_to?(:walk_tree)
-    Mixin.extend ActsAsTree::TreeWalker
+    assert_equal false, TreeMixin.respond_to?(:walk_tree)
+    TreeMixin.extend ActsAsTree::TreeWalker
     assert_equal true,  TreeMixin.respond_to?(:walk_tree)
 
-    walk_tree_output = <<-END.gsub(/^\s+/, '')
+    walk_tree_dfs_output = <<-END.gsub(/^\s+/, '')
       1
       -2
       --3
@@ -279,7 +279,18 @@ class TreeTest < MiniTest::Unit::TestCase
       6
       7
       END
-    assert_equal walk_tree_output, capture_stdout { TreeMixin.walk_tree{|elem, indent| puts "#{indent}#{elem.id}"} }
+    assert_equal walk_tree_dfs_output, capture_stdout { TreeMixin.walk_tree{|elem, level| puts "#{'-'*level}#{elem.id}"} }
+
+    walk_tree_bfs_output = <<-END.gsub(/^\s+/, '')
+      1
+      6
+      7
+      -2
+      -5
+      --3
+      ---4
+      END
+    assert_equal walk_tree_bfs_output, capture_stdout { TreeMixin.walk_tree(:algorithm => :bfs){|elem, level| puts "#{'-'*level}#{elem.id}"} }
   end
 end
 


### PR DESCRIPTION
TreeWalker is an optional add-on (like TreeView) that helps traversing the tree in a convenient way: call a given block with the current node and current depth-level. Both common traversing algorithms are implemented:  depth-first search (DFS, default) and  breadth-first search (BFS). Additionally an ActiveRecord `where` statement to filter certain nodes can be given.
