### PR TITLE
Fix rails versions in gemfiles

### DIFF
--- a/gemfiles/rails-3.0.gemfile
+++ b/gemfiles/rails-3.0.gemfile
@@ -2,5 +2,6 @@ source "https://rubygems.org"
 
 gem "rails", "~> 3.0.0"
 gem "acts_as_tree", path: "../"
+gem "i18n", "< 0.7"
 
 gemspec path: "../"

--- a/gemfiles/rails-3.0.gemfile
+++ b/gemfiles/rails-3.0.gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "rails", "~> 3.0"
+gem "rails", "~> 3.0.0"
 gem "acts_as_tree", path: "../"
 
 gemspec path: "../"

--- a/gemfiles/rails-3.1.gemfile
+++ b/gemfiles/rails-3.1.gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "rails", "~> 3.1"
+gem "rails", "~> 3.1.0"
 gem "acts_as_tree", path: "../"
 
 gemspec path: "../"

--- a/gemfiles/rails-3.1.gemfile
+++ b/gemfiles/rails-3.1.gemfile
@@ -2,5 +2,6 @@ source "https://rubygems.org"
 
 gem "rails", "~> 3.1.0"
 gem "acts_as_tree", path: "../"
+gem "i18n", "< 0.7"
 
 gemspec path: "../"

--- a/gemfiles/rails-3.2.gemfile
+++ b/gemfiles/rails-3.2.gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "rails", "~> 3.2"
+gem "rails", "~> 3.2.0"
 gem "acts_as_tree", path: "../"
 
 gemspec path: "../"

--- a/gemfiles/rails-3.2.gemfile
+++ b/gemfiles/rails-3.2.gemfile
@@ -2,5 +2,6 @@ source "https://rubygems.org"
 
 gem "rails", "~> 3.2.0"
 gem "acts_as_tree", path: "../"
+gem "i18n", "< 0.7"
 
 gemspec path: "../"

--- a/gemfiles/rails-4.0.gemfile
+++ b/gemfiles/rails-4.0.gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "rails", "~> 4.0"
+gem "rails", "~> 4.0.0"
 gem "acts_as_tree", path: "../"
 
 gemspec path: "../"

--- a/test/acts_as_tree_test.rb
+++ b/test/acts_as_tree_test.rb
@@ -24,7 +24,12 @@ class MiniTest::Unit::TestCase
       end
     }
 
-    result = ActiveSupport::Notifications.subscribed(counter_f, "sql.active_record", &block)
+    begin
+      subscribed = ActiveSupport::Notifications.subscribe("sql.active_record", &counter_f)
+      result = block.call
+    ensure
+      ActiveSupport::Notifications.unsubscribe subscribed
+    end
 
     [count, result]
   end


### PR DESCRIPTION
Hello!

Rails versions in gemfiles/ are incorrect.
Lets see, for example, https://travis-ci.org/amerine/acts_as_tree/jobs/36291505: it actually runs tests against activerecord 3.2.19, but the `rails-3.1.gemfile` is selected.