### PR TITLE
Make walk tree available for instance (refactored)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ In your view you could traverse the tree using
 <% end %>
 ```
 
+You also could use walk_tree as an instance method such as:
+
+```erb
+<% Page.first.walk_tree do |page, level| %>
+  <%= link_to "#{'-'*level}#{page.name}", page_path(page) %><br />
+<% end %>
+```
+
 ## Compatibility
 
 We no longer support Ruby 1.8 or versions of Rails/ActiveRecord older than 3.0. If you're using a version of ActiveRecord older than 3.0 please use 0.1.1.

--- a/test/acts_as_tree_test.rb
+++ b/test/acts_as_tree_test.rb
@@ -272,8 +272,10 @@ class TreeTest < MiniTest::Unit::TestCase
 
   def test_tree_walker
     assert_equal false, TreeMixin.respond_to?(:walk_tree)
+    assert_equal false, TreeMixin.new.respond_to?(:walk_tree)
     TreeMixin.extend ActsAsTree::TreeWalker
     assert_equal true,  TreeMixin.respond_to?(:walk_tree)
+    assert_equal true,  TreeMixin.new.respond_to?(:walk_tree)
 
     walk_tree_dfs_output = <<-END.gsub(/^\s+/, '')
       1
@@ -286,6 +288,14 @@ class TreeTest < MiniTest::Unit::TestCase
       END
     assert_equal walk_tree_dfs_output, capture_stdout { TreeMixin.walk_tree{|elem, level| puts "#{'-'*level}#{elem.id}"} }
 
+    walk_tree_dfs_sub_output = <<-END.gsub(/^\s+/, '')
+      2
+      -3
+      --4
+      5
+      END
+    assert_equal walk_tree_dfs_sub_output, capture_stdout { @root1.walk_tree{|elem, level| puts "#{'-'*level}#{elem.id}"} }
+
     walk_tree_bfs_output = <<-END.gsub(/^\s+/, '')
       1
       6
@@ -296,6 +306,14 @@ class TreeTest < MiniTest::Unit::TestCase
       ---4
       END
     assert_equal walk_tree_bfs_output, capture_stdout { TreeMixin.walk_tree(:algorithm => :bfs){|elem, level| puts "#{'-'*level}#{elem.id}"} }
+
+    walk_tree_bfs_sub_output = <<-END.gsub(/^\s+/, '')
+      2
+      5
+      -3
+      --4
+      END
+    assert_equal walk_tree_bfs_sub_output, capture_stdout { @root1.walk_tree(:algorithm => :bfs){|elem, level| puts "#{'-'*level}#{elem.id}"} }
   end
 end
 


### PR DESCRIPTION
This builds on the work done by @genewoo done in PR #37 and addresses some of the issues I noticed when reviewing the code:

* remove unneeded root_instance option (use node instead)
* extract dfs and bfs implementations into private class methods
* remove private params needed for recursion from the public walk_tree method signature

I could merge this myself, but I'd like some feedback from the other maintainers first.

One issue here is that we are changing the method signature for `TreeWalker.walk_tree` to remove the extra params used by recursion. These params were never meant for public use, so I think this is OK, but I'd like a second opinion on this. This also plays into the decision wether this should be classified as a major or minor version bump according to semver.

After merging this resolves issue #32. I've not yet squashed the commits but would do so before merging.