### PR TITLE
Fix ruby 1.9.2 specs

### DIFF
--- a/gemfiles/rails-3.1.gemfile
+++ b/gemfiles/rails-3.1.gemfile
@@ -3,5 +3,6 @@ source "https://rubygems.org"
 gem "rails", "~> 3.1.0"
 gem "acts_as_tree", path: "../"
 gem "i18n", "< 0.7"
+gem "rack-cache", "< 1.3"
 
 gemspec path: "../"

--- a/gemfiles/rails-3.2.gemfile
+++ b/gemfiles/rails-3.2.gemfile
@@ -3,5 +3,6 @@ source "https://rubygems.org"
 gem "rails", "~> 3.2.0"
 gem "acts_as_tree", path: "../"
 gem "i18n", "< 0.7"
+gem "rack-cache", "< 1.3"
 
 gemspec path: "../"


### PR DESCRIPTION
Due to an minimum ruby version requirement added to the latest version of rack-cache, the specs break on ruby 1.9.2. As a workaround we can limit to an older version of rack-cache.

See rtomayko/rack-cache#127 for more details.