### PR TITLE
validate and guard against self-referencing nodes

### DIFF
--- a/lib/acts_as_tree.rb
+++ b/lib/acts_as_tree.rb
@@ -1,7 +1,6 @@
 require 'acts_as_tree/version'
 
 module ActsAsTree
-
   if defined? Rails::Railtie
     require 'acts_as_tree/railtie'
   elsif defined? Rails::Initializer
@@ -228,7 +227,7 @@ module ActsAsTree
     #   subchild1.ancestors # => [child1, root]
     def ancestors
       node, nodes = self, []
-      nodes << node = node.parent while node.parent
+      nodes << node = node.parent while node.parent && node.parent != node
       nodes
     end
 
@@ -251,7 +250,7 @@ module ActsAsTree
     # Returns the root node of the tree.
     def root
       node = self
-      node = node.parent while node.parent
+      node = node.parent while node.parent && node.parent != node
       node
     end
 

--- a/test/acts_as_tree_test.rb
+++ b/test/acts_as_tree_test.rb
@@ -535,3 +535,25 @@ class TreeTestWithTouch < MiniTest::Unit::TestCase
     assert @root.updated_at != previous_root_updated_at
   end
 end
+
+class TreeTestWithNodePointingToSelf < MiniTest::Unit::TestCase
+  def setup
+    teardown_db
+    setup_db
+
+    @node = TreeMixin.create!
+    @node.update_attribute(:parent_id, @node.id)
+  end
+
+  def teardown
+    teardown_db
+  end
+
+  def test_root
+    assert_equal @node, @node.root
+  end
+
+  def test_ancestors
+    assert_equal [], @node.ancestors
+  end
+end


### PR DESCRIPTION
I recently came across a data issue that triggered an infinite loop.  When a record's parent foreign key is  identical to the record's own id, methods such as `ancestors` and `root` result in a infinite loop.  This PR:

- adds a validation rule to prevent the parent foreign key column being set to id of the child (to prevent future errors)
- and adds a guard to the `parent` method which raises an exception if the parent is the same as the child (to prevent infinite loops with existing data)