### PR TITLE
Travis CI: Use containerized builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: ruby
+
+sudo: false
+cache: bundler
+
 rvm:
   - 1.9.2
   - 1.9.3


### PR DESCRIPTION
This switches the travis setup to use the newer docker based builds and should also bypass build problems on the new legacy build infrastructure running on GCE (vs. BlueBox), wich ships a bad combo of rubygems 2.5.1 with bundler 1.7.6 (see build failures in PR #44 and bundler/bundler#3558).

We could manually update bundler to 1.11.2, but it adds an unneccessary delay due to the slow rubygems.org api.

This also enables bundler caching to speed up builds.