### PR TITLE
Rails 5 belongs_to should use optional: true.

### DIFF
--- a/lib/acts_as_tree.rb
+++ b/lib/acts_as_tree.rb
@@ -76,11 +76,17 @@ module ActsAsTree
         configuration[:counter_cache] = :children_count
       end
 
-      belongs_to :parent, class_name:    name,
+      belongs_to_opts = {
+        class_name:    name,
         foreign_key:   configuration[:foreign_key],
         counter_cache: configuration[:counter_cache],
         touch:         configuration[:touch],
         inverse_of:    :children
+      }
+
+      belongs_to_opts[:optional] = true if ActiveRecord::VERSION::MAJOR >= 5
+
+      belongs_to :parent, belongs_to_opts
 
       if ActiveRecord::VERSION::MAJOR >= 4
         has_many :children, lambda { order configuration[:order] },


### PR DESCRIPTION
Rails 5 automatically adds a presence validation on belongs_to associations:

* https://github.com/rails/rails/issues/18233
* http://edgeapi.rubyonrails.org/classes/ActiveRecord/Associations/ClassMethods.html#method-i-belongs_to