### PR TITLE
Update Travis CI Build Matrix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 pkg/*
 .rvmrc
 Gemfile.lock
+gemfiles/*.gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,23 +4,39 @@ sudo: false
 cache: bundler
 
 rvm:
-  - 1.9.2
   - 1.9.3
   - 2.0.0
+  - 2.1.8
+  - 2.2.4
 
 gemfile:
   - gemfiles/rails-3.0.gemfile
   - gemfiles/rails-3.1.gemfile
   - gemfiles/rails-3.2.gemfile
   - gemfiles/rails-4.0.gemfile
+  - gemfiles/rails-4.1.gemfile
+  - gemfiles/rails-4.2.gemfile
+  - gemfiles/rails-5.0.gemfile
 
 matrix:
   exclude:
-    # rails 4.0 requries ruby 1.9.3 or newer
-    - rvm: 1.9.2
-      gemfile: gemfiles/rails-4.0.gemfile
-    # rails < 3.2 is unsupported on ruby 2.0
+    # rails < 3.2 is unsupported on ruby 2.0+
     - rvm: 2.0.0
       gemfile: gemfiles/rails-3.0.gemfile
     - rvm: 2.0.0
       gemfile: gemfiles/rails-3.1.gemfile
+    - rvm: 2.1.8
+      gemfile: gemfiles/rails-3.0.gemfile
+    - rvm: 2.1.8
+      gemfile: gemfiles/rails-3.1.gemfile
+    - rvm: 2.2.4
+      gemfile: gemfiles/rails-3.0.gemfile
+    - rvm: 2.2.4
+      gemfile: gemfiles/rails-3.1.gemfile
+    # rails 5.0 requires ruby 2.2.2+
+    - rvm: 1.9.3
+      gemfile: gemfiles/rails-5.0.gemfile
+    - rvm: 2.0.0
+      gemfile: gemfiles/rails-5.0.gemfile
+    - rvm: 2.1.8
+      gemfile: gemfiles/rails-5.0.gemfile

--- a/acts_as_tree.gemspec
+++ b/acts_as_tree.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |s|
   # Dependencies (installed via 'bundle install')...
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "rdoc"
-  s.add_development_dependency "minitest", "~> 4.7.5"
+  s.add_development_dependency "minitest", ">= 4.7.5"
 end

--- a/gemfiles/rails-3.0.gemfile
+++ b/gemfiles/rails-3.0.gemfile
@@ -1,7 +1,6 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 3.0.0"
-gem "acts_as_tree", path: "../"
 gem "i18n", "< 0.7"
 
 gemspec path: "../"

--- a/gemfiles/rails-3.1.gemfile
+++ b/gemfiles/rails-3.1.gemfile
@@ -1,7 +1,6 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 3.1.0"
-gem "acts_as_tree", path: "../"
 gem "i18n", "< 0.7"
 gem "rack-cache", "< 1.3"
 

--- a/gemfiles/rails-3.2.gemfile
+++ b/gemfiles/rails-3.2.gemfile
@@ -1,7 +1,6 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 3.2.0"
-gem "acts_as_tree", path: "../"
 gem "i18n", "< 0.7"
 gem "rack-cache", "< 1.3"
 

--- a/gemfiles/rails-4.1.gemfile
+++ b/gemfiles/rails-4.1.gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 
-gem "rails", "~> 4.0.0"
+gem "rails", "~> 4.1.0"
 
 gemspec path: "../"

--- a/gemfiles/rails-4.2.gemfile
+++ b/gemfiles/rails-4.2.gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 
-gem "rails", "~> 4.0.0"
+gem "rails", "~> 4.2.0"
 
 gemspec path: "../"

--- a/gemfiles/rails-5.0.gemfile
+++ b/gemfiles/rails-5.0.gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 
-gem "rails", "~> 4.0.0"
+gem "rails", "~> 5.0.0.beta1"
 
 gemspec path: "../"

--- a/test/acts_as_tree_test.rb
+++ b/test/acts_as_tree_test.rb
@@ -3,7 +3,7 @@ require 'minitest/benchmark'
 require 'active_record'
 require 'acts_as_tree'
 
-class MiniTest::Unit::TestCase
+class ActsAsTreeTestCase < (defined?(MiniTest::Test) ? MiniTest::Test : MiniTest::Unit::TestCase)
   def assert_queries(num = 1, &block)
     query_count, result = count_queries(&block)
     result
@@ -65,8 +65,11 @@ def setup_db(counter_cache = false)
 end
 
 def teardown_db
-  ActiveRecord::Base.connection.tables.each do |table|
-    ActiveRecord::Base.connection.drop_table(table)
+  # Silence tables deprecation on rails 5.0
+  ActiveSupport::Deprecation.silence do
+    ActiveRecord::Base.connection.tables.each do |table|
+      ActiveRecord::Base.connection.drop_table(table)
+    end
   end
 end
 
@@ -99,7 +102,7 @@ class TreeMixinWithTouch < Mixin
    acts_as_tree foreign_key: "parent_id", order: "id", touch: true
 end
 
-class TreeTest < MiniTest::Unit::TestCase
+class TreeTest < ActsAsTreeTestCase
 
   def setup
     setup_db
@@ -322,7 +325,7 @@ class TreeTest < MiniTest::Unit::TestCase
   end
 end
 
-class TestDeepDescendantsPerformance < MiniTest::Unit::TestCase
+class TestDeepDescendantsPerformance < ActsAsTreeTestCase
   def setup
     teardown_db
     setup_db
@@ -372,7 +375,7 @@ class TestDeepDescendantsPerformance < MiniTest::Unit::TestCase
   end
 end
 
-class TreeTestWithEagerLoading < MiniTest::Unit::TestCase
+class TreeTestWithEagerLoading < ActsAsTreeTestCase
 
   def setup
     teardown_db
@@ -433,7 +436,7 @@ class TreeTestWithEagerLoading < MiniTest::Unit::TestCase
   end
 end
 
-class TreeTestWithoutOrder < MiniTest::Unit::TestCase
+class TreeTestWithoutOrder < ActsAsTreeTestCase
 
   def setup
     setup_db
@@ -454,7 +457,7 @@ class TreeTestWithoutOrder < MiniTest::Unit::TestCase
   end
 end
 
-class UnsavedTreeTest < MiniTest::Unit::TestCase
+class UnsavedTreeTest < ActsAsTreeTestCase
   def setup
     setup_db
     @root       = TreeMixin.new
@@ -472,7 +475,7 @@ class UnsavedTreeTest < MiniTest::Unit::TestCase
 end
 
 
-class TreeTestWithCounterCache < MiniTest::Unit::TestCase
+class TreeTestWithCounterCache < ActsAsTreeTestCase
   def setup
     teardown_db
     setup_db(true)
@@ -514,7 +517,7 @@ class TreeTestWithCounterCache < MiniTest::Unit::TestCase
 end
 
 
-class TreeTestWithTouch < MiniTest::Unit::TestCase
+class TreeTestWithTouch < ActsAsTreeTestCase
   def setup
     teardown_db
     setup_db


### PR DESCRIPTION
* Add Support for MiniTest 5.0
* Drop ruby 1.9.2 from build matrix (not much difference to 1.9.3)
* Add ruby 2.1/2.2 to build matrix
* Add rails 4.1/4.2/5.0.beta1 to build matrix
* Drop duplicate acts_as_tree from gemfiles (loaded by gemspec)