### PR TITLE
Restore travis ruby 1.9.2 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ sudo: false
 cache: bundler
 
 rvm:
+  - 1.9.2
   - 1.9.3
   - 2.0.0
   - 2.1.8
@@ -20,6 +21,13 @@ gemfile:
 
 matrix:
   exclude:
+    # rails 4.x requries ruby 1.9.3 or newer
+    - rvm: 1.9.2
+      gemfile: gemfiles/rails-4.0.gemfile
+    - rvm: 1.9.2
+      gemfile: gemfiles/rails-4.1.gemfile
+    - rvm: 1.9.2
+      gemfile: gemfiles/rails-4.2.gemfile
     # rails < 3.2 is unsupported on ruby 2.0+
     - rvm: 2.0.0
       gemfile: gemfiles/rails-3.0.gemfile
@@ -34,6 +42,8 @@ matrix:
     - rvm: 2.2.4
       gemfile: gemfiles/rails-3.1.gemfile
     # rails 5.0 requires ruby 2.2.2+
+    - rvm: 1.9.2
+      gemfile: gemfiles/rails-5.0.gemfile
     - rvm: 1.9.3
       gemfile: gemfiles/rails-5.0.gemfile
     - rvm: 2.0.0

--- a/gemfiles/rails-3.2.gemfile
+++ b/gemfiles/rails-3.2.gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "rails", "~> 3.2.0"
+gem "rails", "~> 3.2.22"
 gem "i18n", "< 0.7"
 gem "rack-cache", "< 1.3"
 


### PR DESCRIPTION
Let's keep ruby 1.9.2 tests for now…

These were removed in PR #47, but despite speeding up tests we don't really have a good reason to drop it yet.

Also updated the rails 3.2 gemfile to use 3.2.22, which is the first ruby 2.2 compatible rails 3.2 version.