### PR TITLE
Fix travis tests

### DIFF
--- a/gemfiles/rails-3.0.gemfile
+++ b/gemfiles/rails-3.0.gemfile
@@ -2,5 +2,6 @@ source "https://rubygems.org"
 
 gem "rails", "~> 3.0.0"
 gem "i18n", "< 0.7"
+gem "rake", "< 11"
 
 gemspec path: "../"

--- a/gemfiles/rails-3.1.gemfile
+++ b/gemfiles/rails-3.1.gemfile
@@ -3,5 +3,6 @@ source "https://rubygems.org"
 gem "rails", "~> 3.1.0"
 gem "i18n", "< 0.7"
 gem "rack-cache", "< 1.3"
+gem "rake", "< 11"
 
 gemspec path: "../"

--- a/gemfiles/rails-3.2.gemfile
+++ b/gemfiles/rails-3.2.gemfile
@@ -3,5 +3,6 @@ source "https://rubygems.org"
 gem "rails", "~> 3.2.22"
 gem "i18n", "< 0.7"
 gem "rack-cache", "< 1.3"
+gem "rake", "< 11"
 
 gemspec path: "../"

--- a/gemfiles/rails-4.0.gemfile
+++ b/gemfiles/rails-4.0.gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 4.0.0"
+gem "mime-types", "< 3"
 
 gemspec path: "../"

--- a/gemfiles/rails-4.1.gemfile
+++ b/gemfiles/rails-4.1.gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 4.1.0"
+gem "mime-types", "< 3"
 
 gemspec path: "../"

--- a/gemfiles/rails-4.2.gemfile
+++ b/gemfiles/rails-4.2.gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 4.2.0"
+gem "mime-types", "< 3"
 
 gemspec path: "../"


### PR DESCRIPTION
This fixes two issues were the CI tests are broken due to gems raising there mimimum required ruby versions:

* Downgrade rake to pre-11.0 for rails 3.x to restore ruby 1.9.2 support
* Downgrade mime-type to pre-3.0 for rails 4.x to restore ruby 1.9.3 support