### PR TITLE
Allow for use of a different primary key

### DIFF
--- a/test/acts_as_tree_test.rb
+++ b/test/acts_as_tree_test.rb
@@ -47,7 +47,7 @@ end
 
 ActiveRecord::Base.establish_connection adapter: "sqlite3", database: ":memory:"
 
-def setup_db(counter_cache = false)
+def setup_db(counter_cache = false, external_ids = false)
   # AR keeps printing annoying schema statements
   capture_stdout do
     ActiveRecord::Base.logger
@@ -55,6 +55,8 @@ def setup_db(counter_cache = false)
       create_table :mixins do |t|
         t.column :type, :string
         t.column :parent_id, :integer
+        t.column :external_id, :integer if external_ids
+        t.column :external_parent_id, :integer if external_ids
         t.column(:children_count, :integer, default: 0) if counter_cache
         t.timestamps null: false
       end
@@ -99,21 +101,30 @@ class RecursivelyCascadedTreeMixin < Mixin
 end
 
 class TreeMixinWithTouch < Mixin
-   acts_as_tree foreign_key: "parent_id", order: "id", touch: true
+  acts_as_tree foreign_key: "parent_id", order: "id", touch: true
+end
+
+class ExternalTreeMixin < Mixin
+  acts_as_tree foreign_key: "external_parent_id", primary_key: "external_id"
+end
+
+class ExternalTreeMixinNullify < Mixin
+  acts_as_tree foreign_key: "external_parent_id", primary_key: "external_id", order: "id", dependent: :nullify
 end
 
 class TreeTest < ActsAsTreeTestCase
 
   def setup
     setup_db
+    @tree_mixin = TreeMixin
 
-    @root1              = TreeMixin.create!
-    @root_child1        = TreeMixin.create! parent_id: @root1.id
-    @child1_child       = TreeMixin.create! parent_id: @root_child1.id
-    @child1_child_child = TreeMixin.create! parent_id: @child1_child.id
-    @root_child2        = TreeMixin.create! parent_id: @root1.id
-    @root2              = TreeMixin.create!
-    @root3              = TreeMixin.create!
+    @root1              = @tree_mixin.create!
+    @root_child1        = @tree_mixin.create! parent_id: @root1.id
+    @child1_child       = @tree_mixin.create! parent_id: @root_child1.id
+    @child1_child_child = @tree_mixin.create! parent_id: @child1_child.id
+    @root_child2        = @tree_mixin.create! parent_id: @root1.id
+    @root2              = @tree_mixin.create!
+    @root3              = @tree_mixin.create!
   end
 
   def teardown
@@ -135,12 +146,12 @@ class TreeTest < ActsAsTreeTestCase
   end
 
   def test_delete
-    assert_equal 7, TreeMixin.count
+    assert_equal 7, @tree_mixin.count
     @root1.destroy
-    assert_equal 2, TreeMixin.count
+    assert_equal 2, @tree_mixin.count
     @root2.destroy
     @root3.destroy
-    assert_equal 0, TreeMixin.count
+    assert_equal 0, @tree_mixin.count
   end
 
   def test_insert
@@ -166,7 +177,7 @@ class TreeTest < ActsAsTreeTestCase
   end
 
   def test_root
-    assert_equal @root1, TreeMixin.root
+    assert_equal @root1, @tree_mixin.root
     assert_equal @root1, @root1.root
     assert_equal @root1, @root_child1.root
     assert_equal @root1, @child1_child.root
@@ -176,15 +187,15 @@ class TreeTest < ActsAsTreeTestCase
   end
 
   def test_roots
-    assert_equal [@root1, @root2, @root3], TreeMixin.roots
+    assert_equal [@root1, @root2, @root3], @tree_mixin.roots
   end
 
   def test_leaves
-    assert_equal [@child1_child_child, @root_child2, @root2, @root3], TreeMixin.leaves
+    assert_equal [@child1_child_child, @root_child2, @root2, @root3], @tree_mixin.leaves
   end
 
   def test_default_tree_order
-    assert_equal [@root1, @root_child1, @child1_child, @child1_child_child, @root_child2, @root2, @root3], TreeMixin.default_tree_order
+    assert_equal [@root1, @root_child1, @child1_child, @child1_child_child, @root_child2, @root2, @root3], @tree_mixin.default_tree_order
   end
 
   def test_siblings
@@ -261,9 +272,9 @@ class TreeTest < ActsAsTreeTestCase
   end
 
   def test_tree_view
-    assert_equal false, Mixin.respond_to?(:tree_view)
-    Mixin.extend ActsAsTree::TreeView
-    assert_equal true,  TreeMixin.respond_to?(:tree_view)
+    assert_equal false, @tree_mixin.respond_to?(:tree_view)
+    @tree_mixin.extend ActsAsTree::TreeView
+    assert_equal true,  @tree_mixin.respond_to?(:tree_view)
 
     tree_view_outputs = <<-END.gsub(/^ {6}/, '')
       root
@@ -275,15 +286,15 @@ class TreeTest < ActsAsTreeTestCase
        |_ 6
        |_ 7
     END
-    assert_equal tree_view_outputs, capture_stdout { TreeMixin.tree_view(:id) }
+    assert_equal tree_view_outputs, capture_stdout { @tree_mixin.tree_view(:id) }
   end
 
   def test_tree_walker
-    assert_equal false, TreeMixin.respond_to?(:walk_tree)
-    assert_equal false, TreeMixin.new.respond_to?(:walk_tree)
-    TreeMixin.extend ActsAsTree::TreeWalker
-    assert_equal true,  TreeMixin.respond_to?(:walk_tree)
-    assert_equal true,  TreeMixin.new.respond_to?(:walk_tree)
+    assert_equal false, @tree_mixin.respond_to?(:walk_tree)
+    assert_equal false, @tree_mixin.new.respond_to?(:walk_tree)
+    @tree_mixin.extend ActsAsTree::TreeWalker
+    assert_equal true,  @tree_mixin.respond_to?(:walk_tree)
+    assert_equal true,  @tree_mixin.new.respond_to?(:walk_tree)
 
     walk_tree_dfs_output = <<-END.gsub(/^\s+/, '')
       1
@@ -294,7 +305,7 @@ class TreeTest < ActsAsTreeTestCase
       6
       7
       END
-    assert_equal walk_tree_dfs_output, capture_stdout { TreeMixin.walk_tree{|elem, level| puts "#{'-'*level}#{elem.id}"} }
+    assert_equal walk_tree_dfs_output, capture_stdout { @tree_mixin.walk_tree{|elem, level| puts "#{'-'*level}#{elem.id}"} }
 
     walk_tree_dfs_sub_output = <<-END.gsub(/^\s+/, '')
       2
@@ -313,7 +324,7 @@ class TreeTest < ActsAsTreeTestCase
       --3
       ---4
       END
-    assert_equal walk_tree_bfs_output, capture_stdout { TreeMixin.walk_tree(:algorithm => :bfs){|elem, level| puts "#{'-'*level}#{elem.id}"} }
+    assert_equal walk_tree_bfs_output, capture_stdout { @tree_mixin.walk_tree(:algorithm => :bfs){|elem, level| puts "#{'-'*level}#{elem.id}"} }
 
     walk_tree_bfs_sub_output = <<-END.gsub(/^\s+/, '')
       2
@@ -536,5 +547,34 @@ class TreeTestWithTouch < ActsAsTreeTestCase
     @root.reload
     
     assert @root.updated_at != previous_root_updated_at
+  end
+end
+
+class ExternalTreeTest < TreeTest
+  def setup
+    teardown_db
+    setup_db false, true
+    @tree_mixin = ExternalTreeMixin
+
+    @root1              = @tree_mixin.create! external_id: 1101
+    @root_child1        = @tree_mixin.create! external_id: 1102, external_parent_id: @root1.external_id
+    @child1_child       = @tree_mixin.create! external_id: 1103, external_parent_id: @root_child1.external_id
+    @child1_child_child = @tree_mixin.create! external_id: 1104, external_parent_id: @child1_child.external_id
+    @root_child2        = @tree_mixin.create! external_id: 1105, external_parent_id: @root1.external_id
+    @root2              = @tree_mixin.create! external_id: 1106
+    @root3              = @tree_mixin.create! external_id: 1107
+  end
+
+  def test_nullify
+    root4       = ExternalTreeMixinNullify.create! external_id: 1108
+    root4_child = ExternalTreeMixinNullify.create! external_id: 1109, external_parent_id: root4.external_id
+
+    assert_equal 2, ExternalTreeMixinNullify.count
+    assert_equal root4.external_id, root4_child.external_parent_id
+
+    root4.destroy
+
+    assert_equal 1, ExternalTreeMixinNullify.count
+    assert_nil root4_child.reload.external_parent_id
   end
 end

--- a/test/acts_as_tree_test.rb
+++ b/test/acts_as_tree_test.rb
@@ -62,6 +62,11 @@ def setup_db(counter_cache = false, external_ids = false)
       end
     end
 
+    # Fix broken reset_column_information in some activerecord versions.
+    if ActiveRecord::VERSION::MAJOR == 3 && ActiveRecord::VERSION::MINOR == 2 ||
+       ActiveRecord::VERSION::MAJOR == 4 && ActiveRecord::VERSION::MINOR == 1
+      ActiveRecord::Base.connection.schema_cache.clear!
+    end
     Mixin.reset_column_information
   end
 end


### PR DESCRIPTION
In situations where external tree-based data is cached or otherwise held locally, the ids used by the external service can differ from the database's primary key.

This picks up the work done by @Two9A but adds an additional commit on top to work around bugs with  `ActiveRecord::Base.reset_column_information`, which appears to be ineffective in both activerecord 3.2 and 4.1, which lead to test failures due to the column cache not being invalidated.

Closes #50.