### PR TITLE
Fix database access caused by calling primary_key

### DIFF
--- a/lib/acts_as_tree.rb
+++ b/lib/acts_as_tree.rb
@@ -65,7 +65,7 @@ module ActsAsTree
     #                            a custom column by passing a symbol or string.
     def acts_as_tree(options = {})
       configuration = {
-        primary_key:   primary_key,
+        primary_key:   "id",
         foreign_key:   "parent_id",
         order:         nil,
         counter_cache: nil,


### PR DESCRIPTION
This fixes a regression caused by the change to allow customization of the primary key.

While calling `primary_key` on the model is the proper way to find it's pk, it caused a schema lookup which should be avoided in class methods so things like asset precompilation can be run without
a database present.

This fixes #54.