### PR TITLE
Gererations methods

### DIFF
--- a/lib/acts_as_tree.rb
+++ b/lib/acts_as_tree.rb
@@ -119,6 +119,13 @@ module ActsAsTree
         end
       EOV
 
+      # Returns a hash of all nodes grouped by their level in the tree structure.
+      #
+      # Class.generations { 0=> [root1, root2], 1=> [root1child1, root1child2, root2child1, root2child2] }
+      def self.generations
+        all.group_by{ |node| node.ancestors.size }
+      end
+
       if configuration[:counter_cache]
         after_update :update_parents_counter_cache
 

--- a/lib/acts_as_tree.rb
+++ b/lib/acts_as_tree.rb
@@ -129,7 +129,7 @@ module ActsAsTree
       #
       # Class.generations { 0=> [root1, root2], 1=> [root1child1, root1child2, root2child1, root2child2] }
       def self.generations
-        all.group_by{ |node| node.ancestors.size }
+        all.group_by{ |node| node.level }
       end
 
       if configuration[:counter_cache]
@@ -299,18 +299,16 @@ module ActsAsTree
     #
     #  root1child1.generation [root1child1, root1child2, root2child1, root2child2]
     def self_and_generation
-      self.class.select {|node| node.ancestors.size == self.ancestors.size }
+      self.class.select {|node| node.level == self.level }
     end
 
-    # Returns key for the current nods generation in the generations hash
+    # Returns level (key) for the current nods generation in the generations hash
     #
-    #  root1child1.generation_key 1
-    def generation_key
-      self.class.generations.select {
-        |key, value| value.include?(self)
-      }.keys.first
+    #  root1child1.level 1
+    def level
+      self.ancestors.size
     end
-    
+
     # Returns children (without subchildren) and current node itself.
     #
     #   root.self_and_children # => [root, child1]

--- a/lib/acts_as_tree.rb
+++ b/lib/acts_as_tree.rb
@@ -302,7 +302,7 @@ module ActsAsTree
       self.class.select {|node| node.level == self.level }
     end
 
-    # Returns level (key) for the current nods generation in the generations hash
+    # Returns the level (depth) of the current node
     #
     #  root1child1.level 1
     def level

--- a/lib/acts_as_tree.rb
+++ b/lib/acts_as_tree.rb
@@ -296,6 +296,15 @@ module ActsAsTree
       self.class.select {|node| node.ancestors.size == self.ancestors.size }
     end
 
+    # Returns key for the current nods generation in the generations hash
+    #
+    #  root1child1.generation_key 1
+    def generation_key
+      self.class.generations.select {
+        |key, value| value.include?(self)
+      }.keys.first
+    end
+    
     # Returns children (without subchildren) and current node itself.
     #
     #   root.self_and_children # => [root, child1]

--- a/lib/acts_as_tree.rb
+++ b/lib/acts_as_tree.rb
@@ -282,6 +282,20 @@ module ActsAsTree
       parent ? parent.children : self.class.roots
     end
 
+    # Returns all the nodes at the same level in the tree as the current node.
+    #
+    #  root1child1.generation [root1child2, root2child1, root2child2]
+    def generation
+      self_and_generation - [self]
+    end
+
+    # Returns a reference to the current node and all the nodes at the same level as it in the tree.
+    #
+    #  root1child1.generation [root1child1, root1child2, root2child1, root2child2]
+    def self_and_generation
+      self.class.select {|node| node.ancestors.size == self.ancestors.size }
+    end
+
     # Returns children (without subchildren) and current node itself.
     #
     #   root.self_and_children # => [root, child1]

--- a/test/acts_as_tree_test.rb
+++ b/test/acts_as_tree_test.rb
@@ -570,4 +570,21 @@ class GenertaionMethods < ActsAsTreeTestCase
       TreeMixin.generations
     )
   end
+
+  def test_generation
+    assert_equal [@root2, @root3], @root1.generation
+    assert_equal [@root_child2, @root2_child1, @root2_child2],
+      @root_child1.generation
+    assert_equal [@root2_child1_child], @child1_child.generation
+    assert_equal [], @child1_child_child.generation
+  end
+
+  def test_self_and_generation
+    assert_equal [@root1, @root2, @root3], @root1.self_and_generation
+    assert_equal [@root_child1, @root_child2, @root2_child1, @root2_child2],
+      @root_child1.self_and_generation
+    assert_equal [@child1_child, @root2_child1_child],
+      @child1_child.self_and_generation
+    assert_equal [@child1_child_child], @child1_child_child.self_and_generation
+  end
 end

--- a/test/acts_as_tree_test.rb
+++ b/test/acts_as_tree_test.rb
@@ -538,3 +538,36 @@ class TreeTestWithTouch < ActsAsTreeTestCase
     assert @root.updated_at != previous_root_updated_at
   end
 end
+
+class GenertaionMethods < ActsAsTreeTestCase
+  def setup
+    setup_db
+
+    @root1              = TreeMixin.create!
+    @root_child1        = TreeMixin.create! parent_id: @root1.id
+    @child1_child       = TreeMixin.create! parent_id: @root_child1.id
+    @child1_child_child = TreeMixin.create! parent_id: @child1_child.id
+    @root_child2        = TreeMixin.create! parent_id: @root1.id
+    @root2              = TreeMixin.create!
+    @root2_child1       = TreeMixin.create! parent_id: @root2.id
+    @root2_child2       = TreeMixin.create! parent_id: @root2.id
+    @root2_child1_child = TreeMixin.create! parent_id: @root2_child1.id
+    @root3              = TreeMixin.create!
+  end
+
+  def teardown
+    teardown_db
+  end
+
+  def test_generations
+    assert_equal(
+      {
+        0 => [@root1, @root2, @root3],
+        1 => [@root_child1, @root_child2, @root2_child1, @root2_child2],
+        2 => [@child1_child, @root2_child1_child],
+        3 => [@child1_child_child]
+      },
+      TreeMixin.generations
+    )
+  end
+end

--- a/test/acts_as_tree_test.rb
+++ b/test/acts_as_tree_test.rb
@@ -587,4 +587,11 @@ class GenertaionMethods < ActsAsTreeTestCase
       @child1_child.self_and_generation
     assert_equal [@child1_child_child], @child1_child_child.self_and_generation
   end
+
+  def test_generation_key
+    assert_equal 0, @root1.generation_key
+    assert_equal 1, @root_child1.generation_key
+    assert_equal 2, @child1_child.generation_key
+    assert_equal 3, @child1_child_child.generation_key
+  end
 end

--- a/test/acts_as_tree_test.rb
+++ b/test/acts_as_tree_test.rb
@@ -586,11 +586,11 @@ class GenertaionMethods < ActsAsTreeTestCase
     assert_equal [@child1_child_child], @child1_child_child.self_and_generation
   end
 
-  def test_generation_key
-    assert_equal 0, @root1.generation_key
-    assert_equal 1, @root_child1.generation_key
-    assert_equal 2, @child1_child.generation_key
-    assert_equal 3, @child1_child_child.generation_key
+  def test_level
+    assert_equal 0, @root1.level
+    assert_equal 1, @root_child1.level
+    assert_equal 2, @child1_child.level
+    assert_equal 3, @child1_child_child.level
   end
 end
 


### PR DESCRIPTION
I have added 4 methods to enable  grouping and return of groups of nodes by their level in the tree structure.  Nodes at the same level in the tree structure would be considered a generation Previously needed similar functionality when us acts_as_tree as part of a permission functionality I was extending. I am not sure if this something that is within the scope of the gem but I enjoyed doing it and I would be interested to hear what you think about it. 