### PR TITLE
Rename level to tree_level

### DIFF
--- a/lib/acts_as_tree.rb
+++ b/lib/acts_as_tree.rb
@@ -127,7 +127,7 @@ module ActsAsTree
 
       # Returns a hash of all nodes grouped by their level in the tree structure.
       #
-      # Class.generations { 0=> [root1, root2], 1=> [root1child1, root1child2, root2child1, root2child2] }
+      # Class.generations # => { 0=> [root1, root2], 1=> [root1child1, root1child2, root2child1, root2child2] }
       def self.generations
         all.group_by{ |node| node.level }
       end
@@ -290,21 +290,21 @@ module ActsAsTree
 
     # Returns all the nodes at the same level in the tree as the current node.
     #
-    #  root1child1.generation [root1child2, root2child1, root2child2]
+    #  root1child1.generation # => [root1child2, root2child1, root2child2]
     def generation
       self_and_generation - [self]
     end
 
     # Returns a reference to the current node and all the nodes at the same level as it in the tree.
     #
-    #  root1child1.generation [root1child1, root1child2, root2child1, root2child2]
+    #  root1child1.self_and_generation # => [root1child1, root1child2, root2child1, root2child2]
     def self_and_generation
       self.class.select {|node| node.level == self.level }
     end
 
     # Returns the level (depth) of the current node
     #
-    #  root1child1.level 1
+    #  root1child1.level # => 1
     def level
       self.ancestors.size
     end

--- a/lib/acts_as_tree.rb
+++ b/lib/acts_as_tree.rb
@@ -129,8 +129,9 @@ module ActsAsTree
       #
       # Class.generations # => { 0=> [root1, root2], 1=> [root1child1, root1child2, root2child1, root2child2] }
       def self.generations
-        all.group_by{ |node| node.level }
+        all.group_by{ |node| node.tree_level }
       end
+
 
       if configuration[:counter_cache]
         after_update :update_parents_counter_cache
@@ -299,13 +300,14 @@ module ActsAsTree
     #
     #  root1child1.self_and_generation # => [root1child1, root1child2, root2child1, root2child2]
     def self_and_generation
-      self.class.select {|node| node.level == self.level }
+      self.class.select {|node| node.tree_level == self.tree_level }
     end
 
-    # Returns the level (depth) of the current node
+    # Returns the level (depth) of the current node 
     #
-    #  root1child1.level # => 1
-    def level
+    #  root1child1.tree_level # => 1
+
+    def tree_level
       self.ancestors.size
     end
 

--- a/lib/acts_as_tree.rb
+++ b/lib/acts_as_tree.rb
@@ -306,9 +306,21 @@ module ActsAsTree
     # Returns the level (depth) of the current node 
     #
     #  root1child1.tree_level # => 1
-
     def tree_level
       self.ancestors.size
+    end
+
+    # Returns the level (depth) of the current node unless level is a column on the node. 
+    # Allows backwards compatibility with older versions of the gem.  
+    # Allows integration with apps using level as a column name.
+    #
+    #  root1child1.level # => 1
+    def level
+      if self.class.column_names.include?('level')
+        super
+      else
+        tree_level
+      end
     end
 
     # Returns children (without subchildren) and current node itself.

--- a/test/acts_as_tree_test.rb
+++ b/test/acts_as_tree_test.rb
@@ -541,7 +541,7 @@ class ExternalTreeTest < TreeTest
   end
 end
 
-class GenertaionMethods < ActsAsTreeTestCase
+class GenerationMethods < ActsAsTreeTestCase
   def setup
     setup_db
 

--- a/test/acts_as_tree_test.rb
+++ b/test/acts_as_tree_test.rb
@@ -586,11 +586,11 @@ class GenerationMethods < ActsAsTreeTestCase
     assert_equal [@child1_child_child], @child1_child_child.self_and_generation
   end
 
-  def test_level
-    assert_equal 0, @root1.level
-    assert_equal 1, @root_child1.level
-    assert_equal 2, @child1_child.level
-    assert_equal 3, @child1_child_child.level
+  def test_tree_level
+    assert_equal 0, @root1.tree_level
+    assert_equal 1, @root_child1.tree_level
+    assert_equal 2, @child1_child.tree_level
+    assert_equal 3, @child1_child_child.tree_level
   end
 end
 

--- a/test/acts_as_tree_test.rb
+++ b/test/acts_as_tree_test.rb
@@ -60,6 +60,12 @@ def setup_db(options = {})
         t.column :children_count, :integer, default: 0 if options[:counter_cache]
         t.timestamps null: false
       end
+
+      create_table :level_mixins, force: true do |t|
+        t.column :level, :string
+        t.column :parent_id, :integer
+        t.timestamps null: false
+      end
     end
 
     # Fix broken reset_column_information in some activerecord versions.
@@ -75,8 +81,21 @@ class Mixin < ActiveRecord::Base
   include ActsAsTree
 end
 
+class LevelMixin < ActiveRecord::Base
+  include ActsAsTree
+  acts_as_tree foreign_key: "parent_id", order: "id"
+end
+
 class TreeMixin < Mixin
   acts_as_tree foreign_key: "parent_id", order: "id"
+end
+
+class TreeMixinWithLevelMethod < Mixin
+  acts_as_tree foreign_key: "parent_id", order: "id"
+
+  def level
+    'Has Level Method'
+  end
 end
 
 class TreeMixinWithoutOrder < Mixin
@@ -555,6 +574,8 @@ class GenerationMethods < ActsAsTreeTestCase
     @root2_child2       = TreeMixin.create! parent_id: @root2.id
     @root2_child1_child = TreeMixin.create! parent_id: @root2_child1.id
     @root3              = TreeMixin.create!
+    @level_column       = LevelMixin.create! level: 'Has Level Column'
+    @level_method       = TreeMixinWithLevelMethod.create!
   end
 
   def test_generations
@@ -591,6 +612,18 @@ class GenerationMethods < ActsAsTreeTestCase
     assert_equal 1, @root_child1.tree_level
     assert_equal 2, @child1_child.tree_level
     assert_equal 3, @child1_child_child.tree_level
+  end
+
+  def test_level
+    assert_equal 0, @root1.level
+    assert_equal 1, @root_child1.level
+    assert_equal 2, @child1_child.level
+    assert_equal 3, @child1_child_child.level
+  end
+
+  def test_alias_tree_level
+    assert_equal 'Has Level Method', @level_method.level
+    assert_equal 'Has Level Column', @level_column.level
   end
 end
 


### PR DESCRIPTION
I have had a go at trying to fix the issue around the level described here: https://github.com/amerine/acts_as_tree/issues/58.

I am not sure if it is something you would want to add in but It does seem to solve the problem if replicate the scenario locally.

I have renamed the level method tree_level as suggested. I also think I have been able to allow level to to be used if level is not a column on the recode concerned. I have written some tests to cover such a scenario and tested manually in a rails app  and it seem to work ok. Let me know what you think. 

Also I spotted some typos in my previous work I have correct these and in the first commit so they can be cherry picked if the rest of the work is not wanted. 