### PR TITLE
Fix: DEPRECATION WARNING for Rails 5.1.4

### DIFF
--- a/lib/acts_as_tree.rb
+++ b/lib/acts_as_tree.rb
@@ -358,7 +358,7 @@ module ActsAsTree
     def update_parents_counter_cache
       counter_cache_column = self.class.children_counter_cache_column
 
-      if parent_id_changed?
+      if saved_change_to_parent_id?
         self.class.decrement_counter(counter_cache_column, parent_id_was)
         self.class.increment_counter(counter_cache_column, parent_id)
       end


### PR DESCRIPTION
As of Ruby on Rails 5.1, `attribute_changed?` ActiveRecord method will be deprecated.

The deprecation message:

> DEPRECATION WARNING: The behavior of `attribute_changed?` inside of after callbacks will be changing in the next version of Rails. The new return value will reflect the behavior of calling the method after `save` returned (e.g. the opposite of what it returns now). To maintain the current behavior, use `saved_change_to_attribute?` instead.

Method `saved_change_to_attribute?` is recommended.

According to changes listed above I wants to rename `parent_id_changed?` method to `saved_change_to_parent_id?`.