### PR TITLE
Rails 5.1 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ gemfile:
   - gemfiles/rails-4.1.gemfile
   - gemfiles/rails-4.2.gemfile
   - gemfiles/rails-5.0.gemfile
+  - gemfiles/rails-5.1.gemfile
 
 matrix:
   exclude:
@@ -52,3 +53,12 @@ matrix:
       gemfile: gemfiles/rails-5.0.gemfile
     - rvm: 2.1.8
       gemfile: gemfiles/rails-5.0.gemfile
+    # rails 5.1 requires ruby 2.2.2+
+    - rvm: 1.9.2
+      gemfile: gemfiles/rails-5.1.gemfile
+    - rvm: 1.9.3
+      gemfile: gemfiles/rails-5.1.gemfile
+    - rvm: 2.0.0
+      gemfile: gemfiles/rails-5.1.gemfile
+    - rvm: 2.1.8
+      gemfile: gemfiles/rails-5.1.gemfile

--- a/gemfiles/rails-5.0.gemfile
+++ b/gemfiles/rails-5.0.gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 
-gem "rails", "~> 5.0.0.beta1"
+gem "rails", "~> 5.0.0"
 
 gemspec path: "../"

--- a/gemfiles/rails-5.1.gemfile
+++ b/gemfiles/rails-5.1.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "rails", "~> 5.1.0"
+
+gemspec path: "../"

--- a/lib/acts_as_tree.rb
+++ b/lib/acts_as_tree.rb
@@ -355,12 +355,23 @@ module ActsAsTree
 
     private
 
-    def update_parents_counter_cache
-      counter_cache_column = self.class.children_counter_cache_column
+    if ActiveRecord::VERSION::MAJOR > 5 || ActiveRecord::VERSION::MAJOR == 5 && ActiveRecord::VERSION::MINOR >= 1
+      def update_parents_counter_cache
+        counter_cache_column = self.class.children_counter_cache_column
 
-      if parent_id_changed?
-        self.class.decrement_counter(counter_cache_column, parent_id_was)
-        self.class.increment_counter(counter_cache_column, parent_id)
+        if saved_change_to_parent_id?
+          self.class.decrement_counter(counter_cache_column, parent_id_before_last_save)
+          self.class.increment_counter(counter_cache_column, parent_id)
+        end
+      end
+    else
+      def update_parents_counter_cache
+        counter_cache_column = self.class.children_counter_cache_column
+
+        if parent_id_changed?
+          self.class.decrement_counter(counter_cache_column, parent_id_was)
+          self.class.increment_counter(counter_cache_column, parent_id)
+        end
       end
     end
   end


### PR DESCRIPTION
This adds Rails 5.1 to the CI matrix and  fixes the following deprecation warnings with ActiveRecord 5.1:

> DEPRECATION WARNING: The behavior of `attribute_changed?` inside of after callbacks will be changing in the next version of Rails. The new return value will reflect the behavior of calling the method after `save` returned (e.g. the opposite of what it returns now). To maintain the current behavior, use `saved_change_to_attribute?` instead. (called from update_parents_counter_cache at acts_as_tree/lib/acts_as_tree.rb:361)

> DEPRECATION WARNING: The behavior of `attribute_was` inside of after callbacks will be changing in the next version of Rails. The new return value will reflect the behavior of calling the method after `save` returned (e.g. the opposite of what it returns now). To maintain the current behavior, use `attribute_before_last_save` instead. (called from update_parents_counter_cache at acts_as_tree/lib/acts_as_tree.rb:362)

Closes #67.