### PR TITLE
Fix symbol to string cast in default tree order

### DIFF
--- a/lib/acts_as_tree.rb
+++ b/lib/acts_as_tree.rb
@@ -112,7 +112,7 @@ module ActsAsTree
         include ActsAsTree::InstanceMethods
 
         def self.default_tree_order
-          order_option = %Q{#{configuration.fetch :order, "nil"}}
+          order_option = #{configuration[:order].inspect}
           order(order_option)
         end
 


### PR DESCRIPTION
Rails automatically quotes column names if symbols are given to `relation.order()`, so we need to keep symbols in `default_tree_order` to keep the quoting behavior instead of converting to a string.

Fixes #73