### PR TITLE
Let .roots select roots from any collection.

### DIFF
--- a/lib/acts_as_tree.rb
+++ b/lib/acts_as_tree.rb
@@ -121,7 +121,7 @@ module ActsAsTree
         end
 
         def self.roots
-          where(:#{configuration[:foreign_key]} => nil).default_tree_order
+          where.not(:id => where(:parent => all)).default_tree_order
         end
       EOV
 


### PR DESCRIPTION
I just realized that the .roots method only allows to get the roots from
the top level. Meaning that only nodes with their foreign_key set to nil
are considered roots.

But I think there would be nice if you could get the 'relative' roots.
For example, if we had a system that allowed to 'archive' some records,
we'd probably scope them as `Record.active` which could possibly
exclude some top-level roots, they're effectively nonexistent. Then,
doing `Record.active.roots` now returns the relative roots, counting as
root all those Records whose parent_id points to a record outside the
current scope (including nil parent_ids)

Same for filtered by date, last n number of records.. etc. The top
level `roots` return the same if called on the Class. Please share some
feedback/ thoughts.

Cheers.