### PR TITLE
Deprecations Warning Rails 6

### DIFF
--- a/acts_as_tree.gemspec
+++ b/acts_as_tree.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency "activerecord", ">= 3.0.0"
 
   # Dependencies (installed via 'bundle install')...
-  s.add_development_dependency "sqlite3"
+  s.add_development_dependency "sqlite3", "~> 1.3.13"
   s.add_development_dependency "rdoc"
   s.add_development_dependency "minitest", ">= 4.7.5"
 end

--- a/lib/acts_as_tree.rb
+++ b/lib/acts_as_tree.rb
@@ -113,7 +113,7 @@ module ActsAsTree
 
         def self.default_tree_order
           if ActiveRecord::VERSION::MAJOR > 5 || ActiveRecord::VERSION::MAJOR == 5 && ActiveRecord::VERSION::MINOR >= 2
-            order_option = Arel.sql(#{configuration[:order].inspect})
+            order_option = Arel.sql(#{configuration[:order].inspect}.to_s)
           else
             order_option = #{configuration[:order].inspect}
           end

--- a/lib/acts_as_tree.rb
+++ b/lib/acts_as_tree.rb
@@ -112,7 +112,7 @@ module ActsAsTree
         include ActsAsTree::InstanceMethods
 
         def self.default_tree_order
-          order_option = #{configuration[:order].inspect}
+          order_option = Arel.sql(#{configuration[:order].inspect})
           order(order_option)
         end
 
@@ -303,15 +303,15 @@ module ActsAsTree
       self.class.select {|node| node.tree_level == self.tree_level }
     end
 
-    # Returns the level (depth) of the current node 
+    # Returns the level (depth) of the current node
     #
     #  root1child1.tree_level # => 1
     def tree_level
       self.ancestors.size
     end
 
-    # Returns the level (depth) of the current node unless level is a column on the node. 
-    # Allows backwards compatibility with older versions of the gem.  
+    # Returns the level (depth) of the current node unless level is a column on the node.
+    # Allows backwards compatibility with older versions of the gem.
     # Allows integration with apps using level as a column name.
     #
     #  root1child1.level # => 1

--- a/lib/acts_as_tree.rb
+++ b/lib/acts_as_tree.rb
@@ -112,7 +112,11 @@ module ActsAsTree
         include ActsAsTree::InstanceMethods
 
         def self.default_tree_order
-          order_option = Arel.sql(#{configuration[:order].inspect})
+          if ActiveRecord::VERSION::MAJOR > 5 || ActiveRecord::VERSION::MAJOR == 5 && ActiveRecord::VERSION::MINOR >= 2
+            order_option = Arel.sql(#{configuration[:order].inspect})
+          else
+            order_option = #{configuration[:order].inspect}
+          end
           order(order_option)
         end
 


### PR DESCRIPTION
When run specs for rails 5.2.x i receive 

```
DEPRECATION WARNING: Dangerous query method (method whose arguments are used as raw SQL) called with non-attribute argument(s). 
```

This is because i have complex plain SQL for ordering, and now order in rails must be encoded with Arel.sql to process unsafe sql. 

See [https://github.com/rails/rails/commit/310c3a8f2d043f3d00d3f703052a1e160430a2c2](url)