### PR TITLE
Fix order option with arel nodes

### DIFF
--- a/acts_as_tree.gemspec
+++ b/acts_as_tree.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency "activerecord", ">= 3.0.0"
 
   # Dependencies (installed via 'bundle install')...
-  s.add_development_dependency "sqlite3"
+  s.add_development_dependency "sqlite3", "~> 1.3.6"
   s.add_development_dependency "rdoc"
   s.add_development_dependency "minitest", ">= 4.7.5"
 end

--- a/lib/acts_as_tree.rb
+++ b/lib/acts_as_tree.rb
@@ -108,22 +108,19 @@ module ActsAsTree
           inverse_of:  :parent
       end
 
-      class_eval <<-EOV
-        include ActsAsTree::InstanceMethods
+      include ActsAsTree::InstanceMethods
 
-        def self.default_tree_order
-          order_option = #{configuration[:order].inspect}
-          order(order_option)
-        end
+      define_singleton_method :default_tree_order do
+        order(configuration[:order])
+      end
 
-        def self.root
-          self.roots.first
-        end
+      define_singleton_method :root do
+        self.roots.first
+      end
 
-        def self.roots
-          where(:#{configuration[:foreign_key]} => nil).default_tree_order
-        end
-      EOV
+      define_singleton_method :roots do
+        where(configuration[:foreign_key] => nil).default_tree_order
+      end
 
       # Returns a hash of all nodes grouped by their level in the tree structure.
       #

--- a/test/acts_as_tree_test.rb
+++ b/test/acts_as_tree_test.rb
@@ -51,7 +51,7 @@ def setup_db(options = {})
   # AR keeps printing annoying schema statements
   capture_stdout do
     ActiveRecord::Base.logger
-    ActiveRecord::Schema.define(version: 1) do
+    ActiveRecord::Schema.define do
       create_table :mixins, force: true do |t|
         t.column :type, :string
         t.column :parent_id, :integer


### PR DESCRIPTION
The current code uses `.inspect` within eval, so it only works if inspect returns the actual ruby representation of the code, it works with stuff like `nil` or `{id: :desc}`, but completely breaks for things like `Arel.sql('"foo" DESC, "bar" ASC')`.

Fixes #78