### PR TITLE
Reduce build matrix to speed up builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,70 +5,28 @@ cache: bundler
 
 before_install: gem install bundler -v '~> 1.15' --conservative --minimal-deps
 
-rvm:
-  - 1.9.2
-  - 1.9.3
-  - 2.0.0
-  - 2.1.8
-  - 2.2.4
-
-gemfile:
-  - gemfiles/rails-3.0.gemfile
-  - gemfiles/rails-3.1.gemfile
-  - gemfiles/rails-3.2.gemfile
-  - gemfiles/rails-4.0.gemfile
-  - gemfiles/rails-4.1.gemfile
-  - gemfiles/rails-4.2.gemfile
-  - gemfiles/rails-5.0.gemfile
-  - gemfiles/rails-5.1.gemfile
-  - gemfiles/rails-5.2.gemfile
-
 matrix:
-  exclude:
+  include:
+    - rvm: 1.9.2
+      gemfile: gemfiles/rails-3.0.gemfile
+    - rvm: 1.9.2
+      gemfile: gemfiles/rails-3.1.gemfile
+    - rvm: 1.9.2
+      gemfile: gemfiles/rails-3.2.gemfile
     # rails 4.x requries ruby 1.9.3 or newer
-    - rvm: 1.9.2
+    - rvm: 1.9.3
       gemfile: gemfiles/rails-4.0.gemfile
-    - rvm: 1.9.2
+    - rvm: 1.9.3
       gemfile: gemfiles/rails-4.1.gemfile
-    - rvm: 1.9.2
+    - rvm: 1.9.3
       gemfile: gemfiles/rails-4.2.gemfile
-    # rails < 3.2 is unsupported on ruby 2.0+
-    - rvm: 2.0.0
-      gemfile: gemfiles/rails-3.0.gemfile
-    - rvm: 2.0.0
-      gemfile: gemfiles/rails-3.1.gemfile
-    - rvm: 2.1.8
-      gemfile: gemfiles/rails-3.0.gemfile
-    - rvm: 2.1.8
-      gemfile: gemfiles/rails-3.1.gemfile
-    - rvm: 2.2.4
-      gemfile: gemfiles/rails-3.0.gemfile
-    - rvm: 2.2.4
-      gemfile: gemfiles/rails-3.1.gemfile
-    # rails 5.0 requires ruby 2.2.2+
-    - rvm: 1.9.2
+    # rails 5.x requires ruby 2.2.2+
+    - rvm: 2.2.10
       gemfile: gemfiles/rails-5.0.gemfile
-    - rvm: 1.9.3
-      gemfile: gemfiles/rails-5.0.gemfile
-    - rvm: 2.0.0
-      gemfile: gemfiles/rails-5.0.gemfile
-    - rvm: 2.1.8
-      gemfile: gemfiles/rails-5.0.gemfile
-    # rails 5.1 requires ruby 2.2.2+
-    - rvm: 1.9.2
+    - rvm: 2.2.10
       gemfile: gemfiles/rails-5.1.gemfile
-    - rvm: 1.9.3
-      gemfile: gemfiles/rails-5.1.gemfile
-    - rvm: 2.0.0
-      gemfile: gemfiles/rails-5.1.gemfile
-    - rvm: 2.1.8
-      gemfile: gemfiles/rails-5.1.gemfile
-    # rails 5.2 requires ruby 2.2.2+
-    - rvm: 1.9.2
+    - rvm: 2.2.10
       gemfile: gemfiles/rails-5.2.gemfile
-    - rvm: 1.9.3
-      gemfile: gemfiles/rails-5.2.gemfile
-    - rvm: 2.0.0
-      gemfile: gemfiles/rails-5.2.gemfile
-    - rvm: 2.1.8
+    # test latest stable rails and ruby
+    - rvm: 2.6.1
       gemfile: gemfiles/rails-5.2.gemfile


### PR DESCRIPTION
This reduces the build matrix to ensure we support each rails version with the lowest supported ruby version as well as latest stable rails with latest stable ruby.

This now requires 10 instead of 24 build jobs.