### PR TITLE
Rails 6.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,20 +13,23 @@ matrix:
       gemfile: gemfiles/rails-3.1.gemfile
     - rvm: 1.9.2
       gemfile: gemfiles/rails-3.2.gemfile
-    # rails 4.x requries ruby 1.9.3 or newer
+    # rails 4.x requries ruby >= 1.9.3
     - rvm: 1.9.3
       gemfile: gemfiles/rails-4.0.gemfile
     - rvm: 1.9.3
       gemfile: gemfiles/rails-4.1.gemfile
     - rvm: 1.9.3
       gemfile: gemfiles/rails-4.2.gemfile
-    # rails 5.x requires ruby 2.2.2+
+    # rails 5.x requires ruby >= 2.2.2
     - rvm: 2.2.10
       gemfile: gemfiles/rails-5.0.gemfile
     - rvm: 2.2.10
       gemfile: gemfiles/rails-5.1.gemfile
     - rvm: 2.2.10
       gemfile: gemfiles/rails-5.2.gemfile
-    # test latest stable rails and ruby
+    # rails 6.x requires ruby >= 2.5.0
+    - rvm: 2.5.3
+      gemfile: gemfiles/rails-6.0.gemfile
+    # test latest rails and ruby
     - rvm: 2.6.1
-      gemfile: gemfiles/rails-5.2.gemfile
+      gemfile: gemfiles/rails-6.0.gemfile

--- a/gemfiles/rails-6.0.gemfile
+++ b/gemfiles/rails-6.0.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "rails", "~> 6.0.0.beta"
+
+gemspec path: "../"

--- a/test/acts_as_tree_test.rb
+++ b/test/acts_as_tree_test.rb
@@ -4,6 +4,8 @@ require 'active_record'
 require 'acts_as_tree'
 
 class ActsAsTreeTestCase < (defined?(MiniTest::Test) ? MiniTest::Test : MiniTest::Unit::TestCase)
+  UPDATE_METHOD = ActiveRecord::VERSION::MAJOR >= 4 ? :update : :update_attributes
+
   def assert_queries(num = 1, &block)
     query_count, result = count_queries(&block)
     result
@@ -497,7 +499,7 @@ class TreeTestWithCounterCache < ActsAsTreeTestCase
   end
 
   def test_update_parents_counter_cache
-    @child1_child1.update_attributes(:parent_id => @root.id)
+    @child1_child1.public_send(UPDATE_METHOD, :parent_id => @root.id)
     assert_equal 3, @root.reload.children_count
     assert_equal 0, @child1.reload.children_count
   end
@@ -525,7 +527,7 @@ class TreeTestWithTouch < ActsAsTreeTestCase
 
   def test_updated_at
     previous_root_updated_at = @root.updated_at
-    @child.update_attributes(:type => "new_type")
+    @child.public_send(UPDATE_METHOD, :type => "new_type")
     @root.reload
 
     assert @root.updated_at != previous_root_updated_at


### PR DESCRIPTION
Adds rails 6.0.0.beta to the build matrix and fixes the `update_attributes` deprecation warning in the test suite.