### PR TITLE
Update build matrix to rails 6.0.0 final

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,12 @@ before_install: gem install bundler -v '~> 1.15' --conservative --minimal-deps
 
 matrix:
   include:
-    - rvm: 1.9.2
+    # using ruby 1.9.3 for lack of 1.9.2 rvm binaries
+    - rvm: 1.9.3
       gemfile: gemfiles/rails-3.0.gemfile
-    - rvm: 1.9.2
+    - rvm: 1.9.3
       gemfile: gemfiles/rails-3.1.gemfile
-    - rvm: 1.9.2
+    - rvm: 1.9.3
       gemfile: gemfiles/rails-3.2.gemfile
     # rails 4.x requries ruby >= 1.9.3
     - rvm: 1.9.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,8 @@ matrix:
     - rvm: 2.2.10
       gemfile: gemfiles/rails-5.2.gemfile
     # rails 6.x requires ruby >= 2.5.0
-    - rvm: 2.5.3
+    - rvm: 2.5.6
       gemfile: gemfiles/rails-6.0.gemfile
     # test latest rails and ruby
-    - rvm: 2.6.1
+    - rvm: 2.6.4
       gemfile: gemfiles/rails-6.0.gemfile

--- a/acts_as_tree.gemspec
+++ b/acts_as_tree.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency "activerecord", ">= 3.0.0"
 
   # Dependencies (installed via 'bundle install')...
-  s.add_development_dependency "sqlite3", "~> 1.3.6"
+  s.add_development_dependency "sqlite3"
   s.add_development_dependency "rdoc"
   s.add_development_dependency "minitest", ">= 4.7.5"
 end

--- a/gemfiles/rails-3.0.gemfile
+++ b/gemfiles/rails-3.0.gemfile
@@ -3,5 +3,6 @@ source "https://rubygems.org"
 gem "rails", "~> 3.0.0"
 gem "i18n", "< 0.7"
 gem "rake", "< 11"
+gem "sqlite3", "~> 1.3.4"
 
 gemspec path: "../"

--- a/gemfiles/rails-3.1.gemfile
+++ b/gemfiles/rails-3.1.gemfile
@@ -4,5 +4,6 @@ gem "rails", "~> 3.1.0"
 gem "i18n", "< 0.7"
 gem "rack-cache", "< 1.3"
 gem "rake", "< 11"
+gem "sqlite3", "~> 1.3.4"
 
 gemspec path: "../"

--- a/gemfiles/rails-3.2.gemfile
+++ b/gemfiles/rails-3.2.gemfile
@@ -4,5 +4,6 @@ gem "rails", "~> 3.2.22"
 gem "i18n", "< 0.7"
 gem "rack-cache", "< 1.3"
 gem "rake", "< 11"
+gem "sqlite3", "~> 1.3.5"
 
 gemspec path: "../"

--- a/gemfiles/rails-4.0.gemfile
+++ b/gemfiles/rails-4.0.gemfile
@@ -2,5 +2,6 @@ source "https://rubygems.org"
 
 gem "rails", "~> 4.0.0"
 gem "mime-types", "< 3"
+gem "sqlite3", "~> 1.3.6"
 
 gemspec path: "../"

--- a/gemfiles/rails-4.1.gemfile
+++ b/gemfiles/rails-4.1.gemfile
@@ -2,5 +2,6 @@ source "https://rubygems.org"
 
 gem "rails", "~> 4.1.0"
 gem "mime-types", "< 3"
+gem "sqlite3", "~> 1.3.6"
 
 gemspec path: "../"

--- a/gemfiles/rails-4.2.gemfile
+++ b/gemfiles/rails-4.2.gemfile
@@ -3,5 +3,6 @@ source "https://rubygems.org"
 gem "rails", "~> 4.2.0"
 gem "mime-types", "< 3"
 gem "nokogiri", "< 1.7"
+gem "sqlite3", "~> 1.3.6"
 
 gemspec path: "../"

--- a/gemfiles/rails-5.0.gemfile
+++ b/gemfiles/rails-5.0.gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 5.0.0"
+gem "sqlite3", "~> 1.3.6"
 
 gemspec path: "../"

--- a/gemfiles/rails-5.1.gemfile
+++ b/gemfiles/rails-5.1.gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 5.1.0"
+gem "sqlite3", "~> 1.3", ">= 1.3.6"
 
 gemspec path: "../"

--- a/gemfiles/rails-5.2.gemfile
+++ b/gemfiles/rails-5.2.gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 5.2.0"
+gem "sqlite3", "~> 1.3", ">= 1.3.6"
 
 gemspec path: "../"

--- a/gemfiles/rails-6.0.gemfile
+++ b/gemfiles/rails-6.0.gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
-gem "rails", "~> 6.0.0.beta"
+gem "rails", "~> 6.0.0"
+gem "sqlite3", "~> 1.4"
 
 gemspec path: "../"


### PR DESCRIPTION
This requires to bump sqlite to 1.4, so we switch to specifying minimum
required sqlite version in each gemfile.