### PR TITLE
Splat keyword arguments fro belongs_to

### DIFF
--- a/lib/acts_as_tree.rb
+++ b/lib/acts_as_tree.rb
@@ -90,7 +90,7 @@ module ActsAsTree
 
       belongs_to_opts[:optional] = true if ActiveRecord::VERSION::MAJOR >= 5
 
-      belongs_to :parent, belongs_to_opts
+      belongs_to :parent, **belongs_to_opts
 
       if ActiveRecord::VERSION::MAJOR >= 4
         has_many :children, lambda { order configuration[:order] },

--- a/lib/acts_as_tree.rb
+++ b/lib/acts_as_tree.rb
@@ -90,7 +90,11 @@ module ActsAsTree
 
       belongs_to_opts[:optional] = true if ActiveRecord::VERSION::MAJOR >= 5
 
-      belongs_to :parent, **belongs_to_opts
+      if ActiveRecord::VERSION::MAJOR > 5 || (ActiveRecord::VERSION::MAJOR == 5 && ActiveRecord::VERSION::MINOR >= 2)
+        belongs_to :parent, **belongs_to_opts
+      else
+        belongs_to :parent, belongs_to_opts
+      end
 
       if ActiveRecord::VERSION::MAJOR >= 4
         has_many :children, lambda { order configuration[:order] },


### PR DESCRIPTION
...to avoid getting warnings from Ruby 2.7