### PR TITLE
Update some directives in gemspec

### DIFF
--- a/acts_as_tree.gemspec
+++ b/acts_as_tree.gemspec
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 $:.push File.expand_path("../lib", __FILE__)
 require 'acts_as_tree/version'
 
@@ -10,10 +9,9 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/amerine/acts_as_tree'
   s.summary     = %q{Provides a simple tree behaviour to active_record models.}
   s.description = %q{A gem that adds simple support for organizing ActiveRecord models into parent–children relationships.}
+  s.license     = 'MIT'
 
   s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- {test,features}/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
   s.rdoc_options  = ["--charset=UTF-8"]
 


### PR DESCRIPTION
This PR updates some directives in gemspec.
- Remove a magic comment for encoding
- Set `license` as MIT
- Remove deprecated `test_files`
  - Please see the following for details.
    -  rubygems/guides#90
    - rubygems/bundler#3207
- Remove unused `executables`
  - This gem exposes no executables.