### PR TITLE
Bump actions/checkout from v1 to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
 
       - name: Install Ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
This PR updates `actions/checkout` from v1 to v4.
- The last [release of v1](https://github.com/actions/checkout/tree/releases/v1) is almost 5 years ago and there is no reason to use it, so it should be the latest version.
- Using the latest version allows us to use maintained code.
