### PR TITLE
use with_recursive for faster access on rails >= 7.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,23 @@ jobs:
             gemfile: gemfiles/rails-7.0.gemfile
           - ruby-version: 3.1
             gemfile: gemfiles/rails-7.0.gemfile
+          - ruby-version: 3.2
+            gemfile: gemfiles/rails-7.0.gemfile
+          - ruby-version: 3.3
+            gemfile: gemfiles/rails-7.0.gemfile
+          - ruby-version: 3.1
+            gemfile: gemfiles/rails-7.1.gemfile
+          - ruby-version: 3.2
+            gemfile: gemfiles/rails-7.1.gemfile
+          - ruby-version: 3.3
+            gemfile: gemfiles/rails-7.1.gemfile
+          # rails 7.2 requires ruby >= 3.1.0
+          - ruby-version: 3.1
+            gemfile: gemfiles/rails-7.2.gemfile
+          - ruby-version: 3.2
+            gemfile: gemfiles/rails-7.2.gemfile
+          - ruby-version: 3.3
+            gemfile: gemfiles/rails-7.2.gemfile
 
     runs-on: ubuntu-latest
 

--- a/gemfiles/rails-7.1.gemfile
+++ b/gemfiles/rails-7.1.gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gem "rails", "~> 7.1.0"
+gem "sqlite3", "~> 1.4"
+
+gemspec path: "../"

--- a/gemfiles/rails-7.2.gemfile
+++ b/gemfiles/rails-7.2.gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gem "rails", "~> 7.2.0"
+gem "sqlite3", "~> 1.4"
+
+gemspec path: "../"


### PR DESCRIPTION
Rails >= 7.2 added [#with_recursive](https://api.rubyonrails.org/classes/ActiveRecord/QueryMethods.html#method-i-with_recursive), which allows us to write CTE (Common Table Expressions) in postgresql, sqlite and mysql. 

The bigger the tree gets, the slower is traversing it with the current implementation. This PR allows to fetch the whole tree in just 1 query by using #with_recursive. 

Also, added newer versions of ruby and rails to the ci matrix